### PR TITLE
Make metadata tags placeable anywhere

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,9 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20220905174103-7b278df48cfb
 )
 
-require golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/adrg/frontmatter v0.2.0 // indirect
+	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,13 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/adrg/frontmatter v0.2.0 h1:/DgnNe82o03riBd1S+ZDjd43wAmC6W35q67NHeLkPd4=
+github.com/adrg/frontmatter v0.2.0/go.mod h1:93rQCj3z3ZlwyxxpQioRKC1wDLto4aXHrbqIsnH9wmE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gomarkdown/markdown v0.0.0-20220905174103-7b278df48cfb h1:7h+tPfwoUE+qLvWYmsvKSiRlXv6WGorb6PUKaZUclwc=
 github.com/gomarkdown/markdown v0.0.0-20220905174103-7b278df48cfb/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -65,17 +65,14 @@ func (app App) getPage(fp string) (Page, error) {
 
 	// Get metadata
 	lines := strings.Split(string(md), "\n")
-	for lineNumber, line := range lines {
-		if strings.HasPrefix(line, "[_metadata_:title]:- \"") {
-			title := strings.TrimPrefix(line, "[_metadata_:title]:- \"")
-			page.Title = strings.TrimSuffix(title, "\"")
-		}
-		if strings.HasPrefix(line, "[_metadata_:layout]:- \"") {
-			layout := strings.TrimPrefix(line, "[_metadata_:layout]:- \"")
-			page.Layout = strings.TrimSuffix(layout, "\"")
-		}
-		if lineNumber > 2 {
-			break
+	for _, line := range lines {
+		if strings.HasPrefix(line, "[_metadata_:") {
+			value := strings.SplitAfter(line, "\"")[1]
+			if strings.HasPrefix(line, "[_metadata_:title]:-") {
+				page.Title = value
+			} else if strings.HasPrefix(line, "[_metadata_:layout]:-") {
+				page.Layout = value
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/html"
+
+	"github.com/adrg/frontmatter"
 )
 
 type App struct {
@@ -54,6 +56,37 @@ func (app App) getPage(fp string) (Page, error) {
 		fmt.Println("Could not read file: ", fp)
 		return page, err
 	}
+	// Get metadata
+	if strings.HasPrefix(string(md), "---") {
+		// Parse the frontmatter
+		var matter struct {
+			Title  string `yaml:"title"`
+			Layout string `yaml:"layout"`
+		}
+
+		rest, err := frontmatter.Parse(strings.NewReader(string(md)), &matter)
+		if err != nil {
+			fmt.Println("Could not parse frontmatter: ", err)
+			return page, err
+		}
+		page.Title = matter.Title
+		page.Layout = matter.Layout
+
+		md = rest
+	} else {
+		// Parse the metadata
+		lines := strings.Split(string(md), "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "[_metadata_:") {
+				value := strings.SplitAfter(line, "\"")[1]
+				if strings.HasPrefix(line, "[_metadata_:title]:-") {
+					page.Title = value
+				} else if strings.HasPrefix(line, "[_metadata_:layout]:-") {
+					page.Layout = value
+				}
+			}
+		}
+	}
 
 	// render the markdown file
 	opts := html.RendererOptions{
@@ -62,19 +95,6 @@ func (app App) getPage(fp string) (Page, error) {
 	}
 	renderer := html.NewRenderer(opts)
 	page.Body = string(markdown.ToHTML(md, nil, renderer))
-
-	// Get metadata
-	lines := strings.Split(string(md), "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "[_metadata_:") {
-			value := strings.SplitAfter(line, "\"")[1]
-			if strings.HasPrefix(line, "[_metadata_:title]:-") {
-				page.Title = value
-			} else if strings.HasPrefix(line, "[_metadata_:layout]:-") {
-				page.Layout = value
-			}
-		}
-	}
 
 	// If the page metadata cannot be found, return an error to skip the page
 	// This is useful for markdown that are not pages


### PR DESCRIPTION
I see the reason behind limiting checks for metadata to two lines only, but the Prefix check is fast enough (it exits on first not matching character), to not require such limitation.
To make it a nano-second faster, I've made sure there is only one if per line.

This is going to allow placement of the metadata at the end of file or underneath frontmatter.
Fixes #4 