### PR TITLE
Use Title field from metadata in FilePath creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -135,7 +135,9 @@ func (app App) renderPage(page Page) (err error) {
 		fmt.Println("Could not get relative path: ", err)
 		return err
 	}
-	newFilePath := relpath[:len(relpath)-3] + ".html"
+	newFilePath := filepath.Dir(relpath) + "/" + page.Title + ".html"
+	newFilePath = strings.ReplaceAll(newFilePath, " ", "-")
+	newFilePath = strings.ToLower(newFilePath)
 	newFilePath = filepath.Join(app.DistDir, newFilePath)
 	if err := os.MkdirAll(filepath.Dir(newFilePath), 0755); err != nil {
 		fmt.Println("Could not create directory: ", err)


### PR DESCRIPTION
This change makes use of the title field to replace the name of the file.
It is actually very useful in situations where we want the files in our notes to be somehow organised by name, but in public, to have a different name.