### PR TITLE
Fix config ignore list parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,16 +247,20 @@ func InitApp(srcDir string) (App, error) {
 		return app, err
 	}
 	app.DistDir = squatchConfig.DistDir
-	// parse the comma separated list of folders to ignore
+	// load the list of folders to ignore
 	app.IgnoreFolders = map[string]bool{app.DistDir: true}
-	ignoreFoldersList := strings.Split(squatchConfig.IgnoreFolders, ",")
-	for _, folder := range ignoreFoldersList {
+	for _, folder := range squatchConfig.IgnoreFolders {
+		if folder == "" {
+			continue
+		}
 		app.IgnoreFolders[folder] = true
 	}
 	app.IgnoreFiles = map[string]bool{}
-	// parse the comma separated list of files to ignore
-	ignoreFilesList := strings.Split(squatchConfig.IgnoreFiles, ",")
-	for _, file := range ignoreFilesList {
+	// load the list of files to ignore
+	for _, file := range squatchConfig.IgnoreFiles {
+		if file == "" {
+			continue
+		}
 		app.IgnoreFiles[file] = true
 	}
 	// Remove existing dist directory

--- a/parser.go
+++ b/parser.go
@@ -11,8 +11,8 @@ import (
 
 type SquatchConfig struct {
 	DistDir       string      `json:"dist"`
-	IgnoreFolders string      `json:"ignore_folders"`
-	IgnoreFiles   string      `json:"ignore_files"`
+	IgnoreFolders []string    `json:"ignoreFolders"`
+	IgnoreFiles   []string    `json:"ignoreFiles"`
 	ThemeConfig   ThemeConfig `json:"theme"`
 }
 
@@ -100,7 +100,7 @@ func getSquatchConfig(fp string) (SquatchConfig, error) {
 	// read the config file
 	config, err := os.ReadFile(fp)
 	if err != nil {
-		configStruct = SquatchConfig{DistDir: "dist", IgnoreFolders: "", IgnoreFiles: ""}
+		configStruct = SquatchConfig{DistDir: "dist", IgnoreFolders: []string{}, IgnoreFiles: []string{}}
 		return configStruct, nil
 	}
 	err = json.Unmarshal(config, &configStruct)


### PR DESCRIPTION
## Summary
- fix JSON tags and types for ignore lists in parser
- handle ignore lists parsed as arrays in InitApp

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fd56677a0832d9c3597ae61332918