### PR TITLE
docs: move performance info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,6 @@
 # GoSquatch
 
-A super fast Github Action that converts markdown into a static HTML site. This is super useful for personal blogs and project documentation
-to keep pages in standard markdown but also be able to host through Github Pages (or other hosting providers). GoSquatch uses [native golang templating](https://pkg.go.dev/text/template) and [gomarkdown/markdown](https://github.com/gomarkdown/markdown) to handle markdown parsing. It includes a live building
-server so you can easily see your site locally before publishing it.
-
-_How fast?_ 
-
-GoSquatch takes about 3 seconds on Github Actions to execute. This allows with checking out the code and publishing it to Github Pages to only take around 20 - 30 seconds in total execution time. Check out the [GoSquatch-template's Github Actions](https://github.com/themcaffee/GoSquatch-template/actions) for real examples of performance. 
-
-
-_Why is it so fast?_ 
-
-First, there is a separately built and published docker image `themcaffee/gosquatch` that builds an extremely lean docker
-image with only an alpine image and a small binary program file. This allows for this action to pull a very small image hosted on Github that only takes 
-about 3s to pull down. Second, because this is written in Go this allows for a tight binary with super fast execution with the minimal depencies built in 
-the binary. The step to build the pages varies depending on size but will generally be less than 1 second. 
+GoSquatch is a fast Github Action that converts markdown into a static HTML site. This is useful for personal blogs and project documentation to keep pages in standard markdown while hosting them through Github Pages (or other providers). GoSquatch uses [native golang templating](https://pkg.go.dev/text/template) and [gomarkdown/markdown](https://github.com/gomarkdown/markdown) to handle markdown parsing. It includes a live building server so you can easily preview your site locally before publishing it. See the [performance documentation](https://mitchmcaffee.com/GoSquatch/performance) for details on execution speed.
 
 [Check out our documentation built with GoSquatch!](https://themcaffee.github.io/GoSquatch/)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,10 @@
+[_metadata_:title]:- "Performance"
+[_metadata_:layout]:- "index"
+
+# Performance
+
+GoSquatch typically completes its action in about 3 seconds on GitHub Actions. Including checkout and publishing to GitHub Pages, an entire workflow often finishes in 20–30 seconds. See the [GoSquatch-template actions](https://github.com/themcaffee/GoSquatch-template/actions) for real-world examples.
+
+## Why it is fast
+
+The action uses a slim Docker image built from Alpine with a small Go binary. Pulling the image only takes a few seconds and Go's statically compiled binary executes quickly with minimal dependencies. Building pages generally takes less than a second.


### PR DESCRIPTION
## Summary
- trim README performance bragging
- add link to new performance doc
- document GoSquatch performance in docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fdecd656c832daf033757718cdbdd